### PR TITLE
ci: test the PR's code, not the base branch

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -15,6 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # pull_request_target checks out the base branch by default; for PRs,
+          # check out the PR's merged result so we actually test the changes.
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          # pull_request_target checks out the base branch by default; for PRs,
+          # check out the PR's merged result so we actually test the changes.
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod


### PR DESCRIPTION
## Problem

`Test` and `Lint` are triggered by `pull_request_target` with a bare `actions/checkout@v6`. Under `pull_request_target`, checkout defaults to the **base branch (`main`)**, not the PR. So both checks have been validating `main` on every PR rather than the proposed changes.

Consequences:
- A broken `main` makes **every** PR's Test/Lint go red, regardless of the PR's content.
- A PR that *fixes* `main` can never turn its own checks green (chicken-and-egg).

This is exactly what happened with #132 (the `testcontainers-go/modules/azure` bump): `main` had `testcontainers-go v0.42.0` paired with the incompatible `azure v0.41.0`, the test files stopped typechecking, and the bump PR's checks failed because they were compiling broken `main`, not the fix. (`Build` stayed green because `go build`/Docker never compiles `_test.go`.) `main` has since been repaired directly.

## Fix

Check out `refs/pull/<n>/merge` for `pull_request_target` events — the merged result that would land on `main` — while keeping `github.ref` for `push` events so main/tag runs are unchanged.

```yaml
ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.ref }}
```

## Security note

`pull_request_target` runs in the base repo's context with its token/secrets. Checking out and executing PR code (`go test`, lint) under that trigger is a known privilege-escalation footgun for **public** repos with untrusted fork PRs. These jobs declare minimal permissions and expose no secrets to the test/lint steps, so the practical exposure is limited — but if this repo accepts fork PRs, a stronger follow-up is to move Test/Lint to the plain `pull_request` trigger (it checks out the PR by default and runs with a restricted token). Kept `pull_request_target` here to preserve the existing Dependabot token behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)